### PR TITLE
implement non-prefix completion

### DIFF
--- a/company-ctags.el
+++ b/company-ctags.el
@@ -308,6 +308,10 @@ Return a list of all these elements."
   (let ((rlt))
     (dolist (e collection)
       (when (cl-search prefix e)
+        (put-text-property 0 (length e)
+                           'company-ctags-match
+                           (company-ctags--match-bounds prefix e)
+                           e)
         (push e rlt)))
     (nreverse rlt)))
 
@@ -377,7 +381,7 @@ Execute COMMAND with ARG and IGNORED."
                  (company-ctags-buffer-table)
                  (or (company-grab-symbol) 'stop)))
     (candidates (company-ctags--candidates arg))
-    (match (company-ctags--match-bounds (company-grab-symbol) arg))
+    (match (get-text-property 0 'company-ctags-match arg))
     (no-cache company-ctags-non-prefix-completion)
     (location (let ((tags-table-list (company-ctags-buffer-table)))
                 (when (fboundp 'find-tag-noselect)


### PR DESCRIPTION
The technique is simple. Take an example, I put a symbol `hello` under the keys `?h`, `?e`, `?l` and `?o`, that's what makes non-prefix completion possible.

However, this is a modification on the basic mechanism, and currently I have no idea about the impact on the performance. I can do some test later, but I think it's better for you to do the test since you are more experienced at working on large projects.

I have these two goals:

1. I really want to ensure that people can use both normal or non-prefix completion in the same Emacs session. Currently with this implementation you can do things described in https://github.com/redguardtoo/company-ctags/issues/2, using something like
   ``` emacs-lisp
   (defun my-counsel-company ()
     (interactive)
     (company-abort)
     (let ((company-ctags-non-prefix-completion t))
       (call-interactively 'counsel-company)))
   ```
   So people used to normal completion can also use substring filtering to find a symbol when he doesn't remember the name.

2. The speed of normal completion shouldn't be influenced too much. If this happens, maybe we can try using integers computed from 2 chars as the keys. In the worst case, we can split the backends into a normal one and non-prefix one, and use two hash tables for them.